### PR TITLE
If public host disconnect, private host will try to reconnect.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -67,7 +67,14 @@ if [[ -n "${PUBLIC_HOST_ADDR}" && -n "${PUBLIC_HOST_PORT}" ]]; then
     echo "====REMOTE FINGERPRINT===="
 
     echo "=> Setting up the reverse ssh tunnel"
-    sshpass -p ${ROOT_PASS} autossh -M 0 -NgR 1080:localhost:${PROXY_PORT} root@${PUBLIC_HOST_ADDR} -p ${PUBLIC_HOST_PORT}
+    while true
+    do
+        sshpass -p ${ROOT_PASS} autossh -M 0 -o StrictHostKeyChecking=no -NgR 1080:localhost:${PROXY_PORT} root@${PUBLIC_HOST_ADDR} -p ${PUBLIC_HOST_PORT}
+        echo "=> Tunnel Link down!"
+        echo "=> Wait 15 seconds to reconnect"
+        sleep 15
+        echo "=> Reconnecting..."
+    done
 else
     echo "=> Running in public host mode"
     if [ ! -f /.root_pw_set ]; then


### PR DESCRIPTION
-If public host disconnect, private host will try to reconnect.
-Ignore Private Host fingerprint, if you recreate the private host container the key is changed so the retry doesn't work.